### PR TITLE
Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/test/error_test.dart
+++ b/test/error_test.dart
@@ -253,7 +253,7 @@ Future<String> getRequest(String path) async {
 
   final contents = new StringBuffer();
   // ignore: prefer_foreach
-  await for (var chunk in response.transform(utf8.decoder)) {
+  await for (var chunk in response.cast<List<int>>().transform(utf8.decoder)) {
     contents.write(chunk);
   }
 

--- a/test/session_test.dart
+++ b/test/session_test.dart
@@ -202,7 +202,7 @@ Future<TestResponse> getRequest(String path) async {
 
   final contents = new StringBuffer();
   // ignore: prefer_foreach
-  await for (var chunk in response.transform(utf8.decoder)) {
+  await for (var chunk in response.cast<List<int>>().transform(utf8.decoder)) {
     contents.write(chunk);
   }
 
@@ -225,7 +225,7 @@ Future<TestResponse> postRequest(String path, String data) async {
 
   final contents = new StringBuffer();
   // ignore: prefer_foreach
-  await for (var chunk in response.transform(utf8.decoder)) {
+  await for (var chunk in response.cast<List<int>>().transform(utf8.decoder)) {
     contents.write(chunk);
   }
 

--- a/test/woomera_test.dart
+++ b/test/woomera_test.dart
@@ -253,7 +253,7 @@ Future<String> getRequest(String path) async {
 
   final contents = new StringBuffer();
   // ignore: prefer_foreach
-  await for (var chunk in response.transform(utf8.decoder)) {
+  await for (var chunk in response.cast<List<int>>().transform(utf8.decoder)) {
     contents.write(chunk);
   }
 
@@ -276,7 +276,7 @@ Future<String> postRequest(String path, String data) async {
 
   final contents = new StringBuffer();
   // ignore: prefer_foreach
-  await for (var chunk in response.transform(utf8.decoder)) {
+  await for (var chunk in response.cast<List<int>>().transform(utf8.decoder)) {
     contents.write(chunk);
   }
 


### PR DESCRIPTION
An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900