### PR TITLE
Prepare for Uint8List SDK breaking change

### DIFF
--- a/test/error_test.dart
+++ b/test/error_test.dart
@@ -253,7 +253,7 @@ Future<String> getRequest(String path) async {
 
   final contents = new StringBuffer();
   // ignore: prefer_foreach
-  await for (var chunk in response.cast<List<int>>().transform(utf8.decoder)) {
+  await for (var chunk in utf8.decoder.bind(response)) {
     contents.write(chunk);
   }
 

--- a/test/session_test.dart
+++ b/test/session_test.dart
@@ -202,7 +202,7 @@ Future<TestResponse> getRequest(String path) async {
 
   final contents = new StringBuffer();
   // ignore: prefer_foreach
-  await for (var chunk in response.cast<List<int>>().transform(utf8.decoder)) {
+  await for (var chunk in utf8.decoder.bind(response)) {
     contents.write(chunk);
   }
 
@@ -225,7 +225,7 @@ Future<TestResponse> postRequest(String path, String data) async {
 
   final contents = new StringBuffer();
   // ignore: prefer_foreach
-  await for (var chunk in response.cast<List<int>>().transform(utf8.decoder)) {
+  await for (var chunk in utf8.decoder.bind(response)) {
     contents.write(chunk);
   }
 

--- a/test/woomera_test.dart
+++ b/test/woomera_test.dart
@@ -253,7 +253,7 @@ Future<String> getRequest(String path) async {
 
   final contents = new StringBuffer();
   // ignore: prefer_foreach
-  await for (var chunk in response.cast<List<int>>().transform(utf8.decoder)) {
+  await for (var chunk in utf8.decoder.bind(response)) {
     contents.write(chunk);
   }
 
@@ -276,7 +276,7 @@ Future<String> postRequest(String path, String data) async {
 
   final contents = new StringBuffer();
   // ignore: prefer_foreach
-  await for (var chunk in response.cast<List<int>>().transform(utf8.decoder)) {
+  await for (var chunk in utf8.decoder.bind(response)) {
     contents.write(chunk);
   }
 


### PR DESCRIPTION
A recent change to the Dart SDK updated `HttpClientResponse`
to implement `Stream<Uint8List>` rather than implementing
`Stream<List<int>>`.

This forwards-compatible change updates calls to
`Stream.transform(StreamTransformer)` to instead call the
functionally equivalent `StreamTransformer.bind(Stream)`
API, which puts the stream in a covariant position and
thus causes the SDK change to be non-breaking.

https://github.com/dart-lang/sdk/issues/36900
